### PR TITLE
monilab cli spring boot banner off

### DIFF
--- a/exporter/src/main/resources/application.properties
+++ b/exporter/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=monilab-exporter-ex
+spring.main.banner-mode=off


### PR DESCRIPTION
### Example
<img width="583" height="316" alt="스크린샷 2025-09-26 12 02 55" src="https://github.com/user-attachments/assets/979267d7-0a50-4a9c-81e6-734fea53a408" />

### TODO
cli 실행할 때 뜨는 springboot banner를 없앴습니다.

- application.properties
```yml
spring.main.banner-mode=off
```
