### PR TITLE
데이터 db 적재 스케줄러 추가

### DIFF
--- a/exporter/src/main/kotlin/lab/monilabexporterex/MonilabExporterExApplication.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/MonilabExporterExApplication.kt
@@ -2,8 +2,10 @@ package lab.monilabexporterex
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class MonilabExporterExApplication
 
 fun main(args: Array<String>) {

--- a/exporter/src/main/kotlin/lab/monilabexporterex/config/SchedulerConfig.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/config/SchedulerConfig.kt
@@ -1,0 +1,18 @@
+package lab.monilabexporterex.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+
+@Configuration
+class SchedulerConfig {
+
+    @Bean
+    fun taskScheduler(): ThreadPoolTaskScheduler {
+        val scheduler = ThreadPoolTaskScheduler()
+        scheduler.poolSize = 5
+        scheduler.setThreadNamePrefix("metric-scheduler-")
+        return scheduler
+    }
+
+}

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/ApplicationEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/ApplicationEntity.kt
@@ -34,6 +34,6 @@ class ApplicationEntity(
     @Column(name = "custom_metrics", columnDefinition = "TEXT", nullable = false)
     val customMetrics: String,
 
-    @Column(name = "regist_date_time", nullable = false, updatable = false)
-    var registDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "registered_date_time", nullable = false, updatable = false)
+    var registeredDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/ApplicationEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/ApplicationEntity.kt
@@ -1,6 +1,7 @@
 package lab.monilabexporterex.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tb_metric_application")
@@ -32,4 +33,7 @@ class ApplicationEntity(
     @Lob
     @Column(name = "custom_metrics", columnDefinition = "TEXT", nullable = false)
     val customMetrics: String,
+
+    @Column(name = "regist_date_time", nullable = false, updatable = false)
+    var registDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/ClassLoadingInfoEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/ClassLoadingInfoEntity.kt
@@ -33,6 +33,6 @@ class ClassLoadingInfoEntity(
     @Column(name = "reserved_code_cache_size", nullable = false)
     val reservedCodeCacheSize: Long,
 
-    @Column(name = "regist_date_time", nullable = false, updatable = false)
-    var registDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "registered_date_time", nullable = false, updatable = false)
+    var registeredDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/ClassLoadingInfoEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/ClassLoadingInfoEntity.kt
@@ -1,6 +1,7 @@
 package lab.monilabexporterex.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tb_metric_class_loading")
@@ -31,4 +32,7 @@ class ClassLoadingInfoEntity(
 
     @Column(name = "reserved_code_cache_size", nullable = false)
     val reservedCodeCacheSize: Long,
+
+    @Column(name = "regist_date_time", nullable = false, updatable = false)
+    var registDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/CpuEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/CpuEntity.kt
@@ -33,6 +33,6 @@ class CpuEntity(
     @Column(name = "open_fds", nullable = false)
     val openFds: Long,
 
-    @Column(name = "regist_date_time", nullable = false, updatable = false)
-    var registDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "registered_date_time", nullable = false, updatable = false)
+    var registeredDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/CpuEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/CpuEntity.kt
@@ -1,6 +1,7 @@
 package lab.monilabexporterex.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tb_metric_cpu")
@@ -31,4 +32,7 @@ class CpuEntity(
 
     @Column(name = "open_fds", nullable = false)
     val openFds: Long,
+
+    @Column(name = "regist_date_time", nullable = false, updatable = false)
+    var registDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/GcEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/GcEntity.kt
@@ -33,6 +33,6 @@ class GcEntity(
     @Column(name = "gc_strategy", nullable = false)
     val gcStrategy: String,
 
-    @Column(name = "regist_date_time", nullable = false, updatable = false)
-    var registDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "registered_date_time", nullable = false, updatable = false)
+    var registeredDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/GcEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/GcEntity.kt
@@ -1,6 +1,7 @@
 package lab.monilabexporterex.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tb_metric_gc")
@@ -31,4 +32,7 @@ class GcEntity(
 
     @Column(name = "gc_strategy", nullable = false)
     val gcStrategy: String,
+
+    @Column(name = "regist_date_time", nullable = false, updatable = false)
+    var registDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/MemoryEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/MemoryEntity.kt
@@ -39,6 +39,6 @@ class MemoryEntity(
     @Column(name = "max_direct_memory_size", nullable = false)
     val maxDirectMemorySize: Long,
 
-    @Column(name = "regist_date_time", nullable = false, updatable = false)
-    var registDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "registered_date_time", nullable = false, updatable = false)
+    var registeredDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/MemoryEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/MemoryEntity.kt
@@ -1,6 +1,7 @@
 package lab.monilabexporterex.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tb_metric_memory")
@@ -37,4 +38,7 @@ class MemoryEntity(
 
     @Column(name = "max_direct_memory_size", nullable = false)
     val maxDirectMemorySize: Long,
+
+    @Column(name = "regist_date_time", nullable = false, updatable = false)
+    var registDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/NetworkEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/NetworkEntity.kt
@@ -1,6 +1,7 @@
 package lab.monilabexporterex.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tb_metric_network")
@@ -31,4 +32,7 @@ class NetworkEntity(
 
     @Column(name = "prefer_ipv4", nullable = false)
     val preferIPv4: Boolean,
+
+    @Column(name = "regist_date_time", nullable = false, updatable = false)
+    var registDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/NetworkEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/NetworkEntity.kt
@@ -33,6 +33,6 @@ class NetworkEntity(
     @Column(name = "prefer_ipv4", nullable = false)
     val preferIPv4: Boolean,
 
-    @Column(name = "regist_date_time", nullable = false, updatable = false)
-    var registDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "registered_date_time", nullable = false, updatable = false)
+    var registeredDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/ThreadsEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/ThreadsEntity.kt
@@ -1,6 +1,7 @@
 package lab.monilabexporterex.model
 
 import jakarta.persistence.*
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "tb_metric_threads")
@@ -32,4 +33,7 @@ class ThreadsEntity(
     @Lob
     @Column(name = "states", columnDefinition = "TEXT", nullable = false)
     val states: String,
+
+    @Column(name = "regist_date_time", nullable = false, updatable = false)
+    var registDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/ThreadsEntity.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/ThreadsEntity.kt
@@ -34,6 +34,6 @@ class ThreadsEntity(
     @Column(name = "states", columnDefinition = "TEXT", nullable = false)
     val states: String,
 
-    @Column(name = "regist_date_time", nullable = false, updatable = false)
-    var registDateTime: LocalDateTime = LocalDateTime.now()
+    @Column(name = "registered_date_time", nullable = false, updatable = false)
+    var registeredDateTime: LocalDateTime = LocalDateTime.now()
 )

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/mapper/MetricMapper.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/mapper/MetricMapper.kt
@@ -2,6 +2,7 @@ package lab.monilabexporterex.mapper
 
 import lab.monilabexporterex.exporter.data.JvmMonitoringData
 import lab.monilabexporterex.model.*
+import java.time.LocalDateTime
 
 object JvmMonitoringMapper {
 
@@ -15,7 +16,8 @@ object JvmMonitoringMapper {
             survivor = data.survivor,
             old = data.old,
             bufferPoolUsed = data.bufferPoolUsed,
-            maxDirectMemorySize = data.maxDirectMemorySize
+            maxDirectMemorySize = data.maxDirectMemorySize,
+            registDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: MemoryEntity): JvmMonitoringData.Memory =
@@ -38,7 +40,8 @@ object JvmMonitoringMapper {
             pause = data.pause,
             allocationRate = data.allocationRate,
             liveDataSize = data.liveDataSize,
-            gcStrategy = data.gcStrategy
+            gcStrategy = data.gcStrategy,
+            registDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: GcEntity): JvmMonitoringData.Gc =
@@ -59,7 +62,8 @@ object JvmMonitoringMapper {
             peakCount = data.peakCount,
             deadlockedCount = data.deadlockedCount,
             cpuTime = data.cpuTime,
-            states = data.states.toString()
+            states = data.states.toString(),
+            registDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: ThreadsEntity): JvmMonitoringData.Threads =
@@ -90,7 +94,8 @@ object JvmMonitoringMapper {
             uptime = data.uptime,
             startTime = data.startTime,
             loadAverage = data.loadAverage,
-            openFds = data.openFds
+            openFds = data.openFds,
+            registDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: CpuEntity): JvmMonitoringData.Cpu =
@@ -111,7 +116,8 @@ object JvmMonitoringMapper {
             tcpConnections = data.tcpConnections,
             tcpEstablished = data.tcpEstablished,
             openSockets = data.openSockets,
-            preferIPv4 = data.preferIPv4
+            preferIPv4 = data.preferIPv4,
+            registDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: NetworkEntity): JvmMonitoringData.Network =
@@ -132,7 +138,8 @@ object JvmMonitoringMapper {
             codeCacheUsed = data.codeCacheUsed,
             codeCacheMax = data.codeCacheMax,
             compilationTime = data.compilationTime,
-            reservedCodeCacheSize = data.reservedCodeCacheSize
+            reservedCodeCacheSize = data.reservedCodeCacheSize,
+            registDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: ClassLoadingInfoEntity): JvmMonitoringData.ClassLoadingInfo =
@@ -153,7 +160,8 @@ object JvmMonitoringMapper {
             dbConnectionsActive = data.dbConnectionsActive,
             dbConnectionsMax = data.dbConnectionsMax,
             queueTasksPending = data.queueTasksPending,
-            customMetrics = data.customMetrics.toString()
+            customMetrics = data.customMetrics.toString(),
+            registDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: ApplicationEntity): JvmMonitoringData.Application =

--- a/exporter/src/main/kotlin/lab/monilabexporterex/model/mapper/MetricMapper.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/model/mapper/MetricMapper.kt
@@ -17,7 +17,7 @@ object JvmMonitoringMapper {
             old = data.old,
             bufferPoolUsed = data.bufferPoolUsed,
             maxDirectMemorySize = data.maxDirectMemorySize,
-            registDateTime = LocalDateTime.now()
+            registeredDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: MemoryEntity): JvmMonitoringData.Memory =
@@ -41,7 +41,7 @@ object JvmMonitoringMapper {
             allocationRate = data.allocationRate,
             liveDataSize = data.liveDataSize,
             gcStrategy = data.gcStrategy,
-            registDateTime = LocalDateTime.now()
+            registeredDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: GcEntity): JvmMonitoringData.Gc =
@@ -63,7 +63,7 @@ object JvmMonitoringMapper {
             deadlockedCount = data.deadlockedCount,
             cpuTime = data.cpuTime,
             states = data.states.toString(),
-            registDateTime = LocalDateTime.now()
+            registeredDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: ThreadsEntity): JvmMonitoringData.Threads =
@@ -95,7 +95,7 @@ object JvmMonitoringMapper {
             startTime = data.startTime,
             loadAverage = data.loadAverage,
             openFds = data.openFds,
-            registDateTime = LocalDateTime.now()
+            registeredDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: CpuEntity): JvmMonitoringData.Cpu =
@@ -117,7 +117,7 @@ object JvmMonitoringMapper {
             tcpEstablished = data.tcpEstablished,
             openSockets = data.openSockets,
             preferIPv4 = data.preferIPv4,
-            registDateTime = LocalDateTime.now()
+            registeredDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: NetworkEntity): JvmMonitoringData.Network =
@@ -139,7 +139,7 @@ object JvmMonitoringMapper {
             codeCacheMax = data.codeCacheMax,
             compilationTime = data.compilationTime,
             reservedCodeCacheSize = data.reservedCodeCacheSize,
-            registDateTime = LocalDateTime.now()
+            registeredDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: ClassLoadingInfoEntity): JvmMonitoringData.ClassLoadingInfo =
@@ -161,7 +161,7 @@ object JvmMonitoringMapper {
             dbConnectionsMax = data.dbConnectionsMax,
             queueTasksPending = data.queueTasksPending,
             customMetrics = data.customMetrics.toString(),
-            registDateTime = LocalDateTime.now()
+            registeredDateTime = LocalDateTime.now()
         )
 
     fun toData(entity: ApplicationEntity): JvmMonitoringData.Application =

--- a/exporter/src/main/kotlin/lab/monilabexporterex/scheduler/MetricScheduler.kt
+++ b/exporter/src/main/kotlin/lab/monilabexporterex/scheduler/MetricScheduler.kt
@@ -1,0 +1,46 @@
+package lab.monilabexporterex.scheduler
+
+import lab.monilabexporterex.exporter.JvmExporter
+import lab.monilabexporterex.mapper.JvmMonitoringMapper
+import lab.monilabexporterex.model.Label.*
+import lab.monilabexporterex.repository.*
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class JvmMonitoringScheduler(
+    private val jvmExporter: JvmExporter,
+    private val memoryRepository: MemoryRepository,
+    private val gcRepository: GcRepository,
+    private val threadsRepository: ThreadsRepository,
+    private val cpuRepository: CpuRepository,
+    private val networkRepository: NetworkRepository,
+    private val classLoadingRepository: ClassLoadingInfoRepository,
+    private val applicationRepository: ApplicationRepository
+) {
+
+    @Scheduled(fixedRate = 1000)
+    fun collectAndSaveJvmMetrics() {
+        val memoryEntity = JvmMonitoringMapper.toEntity(jvmExporter.getMemoryInfo(), TEST)
+        memoryRepository.save(memoryEntity)
+
+        val gcEntity = JvmMonitoringMapper.toEntity(jvmExporter.getGcInfo(), TEST)
+        gcRepository.save(gcEntity)
+
+        val threadsEntity = JvmMonitoringMapper.toEntity(jvmExporter.getThreadInfo(), TEST)
+        threadsRepository.save(threadsEntity)
+
+        val cpuEntity = JvmMonitoringMapper.toEntity(jvmExporter.getCpuInfo(), TEST)
+        cpuRepository.save(cpuEntity)
+
+        val networkEntity = JvmMonitoringMapper.toEntity(jvmExporter.getNetworkInfo(), TEST)
+        networkRepository.save(networkEntity)
+
+        val classLoadingEntity = JvmMonitoringMapper.toEntity(jvmExporter.getClassLoadingInfo(), TEST)
+        classLoadingRepository.save(classLoadingEntity)
+
+        val applicationEntity = JvmMonitoringMapper.toEntity(jvmExporter.getApplicationInfo(), TEST)
+        applicationRepository.save(applicationEntity)
+    }
+
+}

--- a/exporter/src/main/resources/application.yml
+++ b/exporter/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
         database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
         show-sql: true
         hibernate:
-            ddl-auto: update
+            ddl-auto: create
         properties:
             hibernate:
                 default_batch_fetch_size: 1000


### PR DESCRIPTION
### Description

- 1초 단위로 실행되는 스케줄러 만들고, 해당 스케줄러가 메트릭 가져와서 db에 적재하는 로직 추가했습니다.
<img width="637" height="222" alt="스크린샷 2025-10-18 16 23 22" src="https://github.com/user-attachments/assets/2beecd72-f927-429d-b170-b39bfd70be02" />

<br>

### Changes

- 메트릭 엔티티에 registDateTime 컬럼 추가했습니다.
